### PR TITLE
feat: instance upgrade tag and batch upgrade modal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -599,23 +599,31 @@ pub async fn delete_instance(instance_id: String, state: State<'_, AppState>) ->
     instance::delete_instance(&instance_id)
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInstanceRequest {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub check_update_enabled: Option<bool>,
+}
+
 #[tauri::command]
 pub async fn update_instance(
     app_handle: AppHandle,
     instance_id: String,
-    name: Option<String>,
-    version: Option<String>,
-    host: Option<String>,
-    port: Option<u16>,
+    request: UpdateInstanceRequest,
     state: State<'_, AppState>,
 ) -> Result<()> {
     let _guard = state.process_manager.acquire_guard(&instance_id)?;
     instance::update_instance(
         &instance_id,
-        name.as_deref(),
-        version.as_deref(),
-        host.as_deref(),
-        port,
+        request.name.as_deref(),
+        request.version.as_deref(),
+        request.host.as_deref(),
+        request.port,
+        request.check_update_enabled,
         &app_handle,
     )
     .await

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -348,6 +348,8 @@ pub struct InstanceConfig {
     pub port: u16,
     #[serde(default)]
     pub created_at: String,
+    #[serde(default = "default_true")]
+    pub check_update_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src-tauri/src/instance/crud.rs
+++ b/src-tauri/src/instance/crud.rs
@@ -33,6 +33,7 @@ fn update_instance_config(
     version: Option<&str>,
     host: Option<&str>,
     port: Option<u16>,
+    check_update_enabled: Option<bool>,
 ) -> Result<()> {
     let id = instance_id.to_string();
     let name_owned = name.map(ToOwned::to_owned);
@@ -56,6 +57,9 @@ fn update_instance_config(
         }
         if let Some(p) = port {
             instance.port = p;
+        }
+        if let Some(c) = check_update_enabled {
+            instance.check_update_enabled = c;
         }
         Ok(())
     })
@@ -133,6 +137,7 @@ pub fn create_instance(name: &str, version: &str, port: u16) -> Result<()> {
             host: DEFAULT_INSTANCE_HOST.to_string(),
             port,
             created_at: chrono::Utc::now().to_rfc3339(),
+            check_update_enabled: true,
         };
 
         manifest.instances.insert(key, instance);
@@ -178,6 +183,7 @@ pub async fn update_instance(
     version: Option<&str>,
     host: Option<&str>,
     port: Option<u16>,
+    check_update_enabled: Option<bool>,
     app_handle: &AppHandle,
 ) -> Result<()> {
     validate_instance_id(instance_id)?;
@@ -270,13 +276,20 @@ pub async fn update_instance(
 
         // Update config(version + optional name/port) after the operation completes successfully.
         // This prevents "config says new version" while the deployment hasn't fully finished.
-        update_instance_config(instance_id, name, Some(new_version.as_str()), host, port)?;
+        update_instance_config(
+            instance_id,
+            name,
+            Some(new_version.as_str()),
+            host,
+            port,
+            check_update_enabled,
+        )?;
 
         emit_progress(app_handle, instance_id, "done", "更新完成", 100);
         Ok(())
     } else {
         // No version change
-        update_instance_config(instance_id, name, version, host, port)
+        update_instance_config(instance_id, name, version, host, port, check_update_enabled)
     }
 }
 
@@ -318,6 +331,7 @@ pub fn list_instances(
                 pid_tracker_not_available,
                 configured_host: normalize_instance_host(&inst.host),
                 configured_port: inst.port,
+                check_update_enabled: inst.check_update_enabled,
             }
         })
         .collect();

--- a/src-tauri/src/instance/rebuild.rs
+++ b/src-tauri/src/instance/rebuild.rs
@@ -136,6 +136,7 @@ fn scan_instances() -> Result<HashMap<String, InstanceConfig>> {
             host: DEFAULT_INSTANCE_HOST.to_string(),
             port: 0,
             created_at: chrono::Utc::now().to_rfc3339(),
+            check_update_enabled: true,
         };
 
         instances.insert(instance_id, instance);

--- a/src-tauri/src/instance/types.rs
+++ b/src-tauri/src/instance/types.rs
@@ -16,6 +16,7 @@ pub struct InstanceStatus {
     pub pid_tracker_not_available: bool,
     pub configured_host: String,
     pub configured_port: u16,
+    pub check_update_enabled: bool,
 }
 
 /// Deployment progress event payload.

--- a/src/api.ts
+++ b/src/api.ts
@@ -110,14 +110,18 @@ export const api = {
     name?: string,
     version?: string,
     host?: string,
-    port?: number
+    port?: number,
+    checkUpdateEnabled?: boolean
   ) =>
     invoke<void>('update_instance', {
       instanceId,
-      name: name ?? null,
-      version: version ?? null,
-      host: host ?? null,
-      port: port ?? null,
+      request: {
+        name: name ?? null,
+        version: version ?? null,
+        host: host ?? null,
+        port: port ?? null,
+        checkUpdateEnabled: checkUpdateEnabled ?? null,
+      },
     }),
   startInstance: (instanceId: string) => invoke<number>('start_instance', { instanceId }),
   stopInstance: (instanceId: string) => invoke<void>('stop_instance', { instanceId }),

--- a/src/components/BatchUpgradeModal.tsx
+++ b/src/components/BatchUpgradeModal.tsx
@@ -1,15 +1,24 @@
 import { Button, Modal, Progress, Space, Typography } from 'antd';
+import { WarningOutlined } from '@ant-design/icons';
 import { UPGRADE_STEPS } from '../constants';
 import type { InstanceStatus } from '../types';
 
+export interface LockCheckItem {
+  instance: InstanceStatus;
+  detail: string;
+  lockingProcesses: string[];
+}
+
 export interface BatchUpgradeModalState {
   open: boolean;
+  phase: 'confirm' | 'lockCheck' | 'upgrading' | 'done' | 'error';
   total: number;
   currentIndex: number;
   currentInstanceName: string;
   step: string | null;
   progress: number;
   error: string | null;
+  lockCheckItems: LockCheckItem[];
 }
 
 interface BatchUpgradeModalProps {
@@ -17,6 +26,7 @@ interface BatchUpgradeModalProps {
   instances: InstanceStatus[];
   latestVersion: string | null;
   onStart: () => void;
+  onContinueAfterLockCheck: () => void;
   onClose: () => void;
 }
 
@@ -32,24 +42,38 @@ export function BatchUpgradeModal({
   instances,
   latestVersion,
   onStart,
+  onContinueAfterLockCheck,
   onClose,
 }: BatchUpgradeModalProps) {
-  const { open, total, currentIndex, currentInstanceName, step, progress, error } = state;
+  const {
+    open,
+    phase,
+    total,
+    currentIndex,
+    currentInstanceName,
+    step,
+    progress,
+    error,
+    lockCheckItems,
+  } = state;
 
-  const isConfirming = currentIndex === 0 && !step && !error;
-  const isDone = currentIndex >= total && !error;
+  const isConfirming = phase === 'confirm';
+  const isLockChecking = phase === 'lockCheck';
+  const isDone = phase === 'done';
+  const hasError = phase === 'error';
+  const allowClose = isDone || hasError || isConfirming;
 
   return (
     <Modal
       title="批量更新实例"
       open={open}
       footer={null}
-      closable={isDone || !!error}
+      closable={allowClose}
       maskClosable={false}
-      keyboard={isDone || !!error}
+      keyboard={allowClose}
       onCancel={onClose}
     >
-      {isConfirming ? (
+      {isConfirming && lockCheckItems.length === 0 && (
         <Space direction="vertical" style={{ width: '100%' }}>
           <Typography.Text>
             确定要批量更新以下 {instances.length} 个实例到版本 {latestVersion} 吗？
@@ -68,23 +92,65 @@ export function BatchUpgradeModal({
             </Button>
           </Space>
         </Space>
-      ) : (
+      )}
+
+      {isConfirming && lockCheckItems.length > 0 && (
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Typography.Text type="warning">
+            <WarningOutlined style={{ marginRight: 8 }} />
+            检测到以下实例存在可能被占用的文件，继续更新可能导致数据损坏：
+          </Typography.Text>
+          <ul style={{ margin: 0, paddingLeft: 20, maxHeight: 200, overflow: 'auto' }}>
+            {lockCheckItems.map((item) => (
+              <li key={item.instance.id}>
+                <Typography.Text strong>{item.instance.name}</Typography.Text>
+                <div>
+                  <Typography.Text type="secondary">{item.detail}</Typography.Text>
+                </div>
+                {item.lockingProcesses.length > 0 && (
+                  <div>
+                    <Typography.Text type="secondary">
+                      占用进程: {item.lockingProcesses.join(', ')}
+                    </Typography.Text>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+          <Typography.Text>仍要继续更新吗？</Typography.Text>
+          <Space style={{ marginTop: 16 }}>
+            <Button onClick={onClose}>取消</Button>
+            <Button type="primary" danger onClick={onContinueAfterLockCheck}>
+              仍要更新
+            </Button>
+          </Space>
+        </Space>
+      )}
+
+      {isLockChecking && (
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Typography.Text strong>正在检查文件锁...</Typography.Text>
+          <Progress percent={0} status="active" />
+        </Space>
+      )}
+
+      {!isConfirming && !isLockChecking && (
         <Space direction="vertical" style={{ width: '100%' }}>
           <Typography.Text strong>
-            {error ? '更新失败' : isDone ? '更新完成' : `正在更新：${currentInstanceName}`}
+            {hasError ? '更新失败' : isDone ? '更新完成' : `正在更新：${currentInstanceName}`}
           </Typography.Text>
           <Typography.Text type="secondary">
             {isDone ? '所有实例已更新' : getStepTitle(step)}
           </Typography.Text>
           <Progress
             percent={progress}
-            status={error ? 'exception' : isDone ? 'success' : 'active'}
+            status={hasError ? 'exception' : isDone ? 'success' : 'active'}
           />
           <Typography.Text type="secondary">
             实例进度：{Math.min(currentIndex, total)} / {total}
           </Typography.Text>
           {error && <Typography.Text type="danger">{error}</Typography.Text>}
-          {(isDone || error) && (
+          {(isDone || hasError) && (
             <Button type="primary" onClick={onClose} style={{ marginTop: 8 }}>
               关闭
             </Button>

--- a/src/components/BatchUpgradeModal.tsx
+++ b/src/components/BatchUpgradeModal.tsx
@@ -61,7 +61,10 @@ export function BatchUpgradeModal({
   const isLockChecking = phase === 'lockCheck';
   const isDone = phase === 'done';
   const hasError = phase === 'error';
-  const allowClose = isDone || hasError || isConfirming;
+  // Only allow closing via the upper-right/ESC/mask once the batch workflow is
+  // finished (success or error). During confirm/lockCheck/upgrading the user
+  // must use the explicit buttons to avoid accidental dismissal.
+  const allowClose = isDone || hasError;
 
   return (
     <Modal

--- a/src/components/BatchUpgradeModal.tsx
+++ b/src/components/BatchUpgradeModal.tsx
@@ -1,0 +1,96 @@
+import { Button, Modal, Progress, Space, Typography } from 'antd';
+import { UPGRADE_STEPS } from '../constants';
+import type { InstanceStatus } from '../types';
+
+export interface BatchUpgradeModalState {
+  open: boolean;
+  total: number;
+  currentIndex: number;
+  currentInstanceName: string;
+  step: string | null;
+  progress: number;
+  error: string | null;
+}
+
+interface BatchUpgradeModalProps {
+  state: BatchUpgradeModalState;
+  instances: InstanceStatus[];
+  latestVersion: string | null;
+  onStart: () => void;
+  onClose: () => void;
+}
+
+function getStepTitle(step: string | null): string {
+  if (!step) {
+    return '准备中...';
+  }
+  return UPGRADE_STEPS.find((s) => s.key === step)?.title ?? step;
+}
+
+export function BatchUpgradeModal({
+  state,
+  instances,
+  latestVersion,
+  onStart,
+  onClose,
+}: BatchUpgradeModalProps) {
+  const { open, total, currentIndex, currentInstanceName, step, progress, error } = state;
+
+  const isConfirming = currentIndex === 0 && !step && !error;
+  const isDone = currentIndex >= total && !error;
+
+  return (
+    <Modal
+      title="批量更新实例"
+      open={open}
+      footer={null}
+      closable={isDone || !!error}
+      maskClosable={false}
+      keyboard={isDone || !!error}
+      onCancel={onClose}
+    >
+      {isConfirming ? (
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Typography.Text>
+            确定要批量更新以下 {instances.length} 个实例到版本 {latestVersion} 吗？
+          </Typography.Text>
+          <ul style={{ margin: 0, paddingLeft: 20, maxHeight: 200, overflow: 'auto' }}>
+            {instances.map((inst) => (
+              <li key={inst.id}>
+                {inst.name}（当前: {inst.version}）
+              </li>
+            ))}
+          </ul>
+          <Space style={{ marginTop: 16 }}>
+            <Button onClick={onClose}>取消</Button>
+            <Button type="primary" onClick={onStart}>
+              开始更新
+            </Button>
+          </Space>
+        </Space>
+      ) : (
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Typography.Text strong>
+            {error ? '更新失败' : isDone ? '更新完成' : `正在更新：${currentInstanceName}`}
+          </Typography.Text>
+          <Typography.Text type="secondary">
+            {isDone ? '所有实例已更新' : getStepTitle(step)}
+          </Typography.Text>
+          <Progress
+            percent={progress}
+            status={error ? 'exception' : isDone ? 'success' : 'active'}
+          />
+          <Typography.Text type="secondary">
+            实例进度：{Math.min(currentIndex, total)} / {total}
+          </Typography.Text>
+          {error && <Typography.Text type="danger">{error}</Typography.Text>}
+          {(isDone || error) && (
+            <Button type="primary" onClick={onClose} style={{ marginTop: 8 }}>
+              关闭
+            </Button>
+          )}
+        </Space>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/EditInstanceModal.tsx
+++ b/src/components/EditInstanceModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Form, Input, InputNumber, Modal, Select, Space } from 'antd';
+import { Form, Input, InputNumber, Modal, Select, Space, Tag, Checkbox, Typography } from 'antd';
 import { api } from '../api';
-import type { InstanceStatus, InstalledVersion } from '../types';
+import type { InstanceStatus, GitHubRelease } from '../types';
 
 const DEFAULT_DASHBOARD_HOST = '127.0.0.1';
 
@@ -21,12 +21,14 @@ type EditInstanceValues = {
   hostMode: DashboardHostMode;
   host: string;
   port?: number;
+  checkUpdateEnabled: boolean;
 };
 
 interface EditInstanceModalProps {
   open: boolean;
   instance: InstanceStatus | null;
-  versions: InstalledVersion[];
+  releases: GitHubRelease[];
+  installedVersions: Set<string>;
   onSubmit: (values: EditInstanceValues) => Promise<void>;
   onCancel: () => void;
 }
@@ -40,7 +42,8 @@ function getHostMode(host: string): DashboardHostMode {
 export function EditInstanceModal({
   open,
   instance,
-  versions,
+  releases,
+  installedVersions,
   onSubmit,
   onCancel,
 }: EditInstanceModalProps) {
@@ -58,6 +61,7 @@ export function EditInstanceModal({
         hostMode: getHostMode(host),
         host,
         port: instance.configured_port || 0,
+        checkUpdateEnabled: instance.check_update_enabled,
       });
       return;
     }
@@ -91,13 +95,33 @@ export function EditInstanceModal({
     };
   }, [watchedVersion, instance]);
 
-  const okText =
-    instance && watchedVersion !== instance.version ? (versionCmp > 0 ? '升级' : '降级') : '确定';
+  const isVersionChanged = instance && watchedVersion && watchedVersion !== instance.version;
+  const changeAction = isVersionChanged ? (versionCmp > 0 ? '升级' : '降级') : null;
+  const okText = changeAction ?? '确定';
 
   const versionOptions = useMemo(
-    () => versions.map((v) => ({ label: v.version, value: v.version })),
-    [versions]
+    () =>
+      releases.map((release) => ({
+        label: (
+          <Space>
+            {release.name || release.tag_name}
+            {installedVersions.has(release.tag_name) ? (
+              <Tag color="green">已下载</Tag>
+            ) : (
+              <Tag>未下载</Tag>
+            )}
+            {release.prerelease && <Tag color="orange">预发行</Tag>}
+          </Space>
+        ),
+        value: release.tag_name,
+      })),
+    [releases, installedVersions]
   );
+
+  const willDownloadVersion =
+    watchedVersion &&
+    instance?.version !== watchedVersion &&
+    !installedVersions.has(watchedVersion);
 
   return (
     <Modal
@@ -115,6 +139,14 @@ export function EditInstanceModal({
         </Form.Item>
         <Form.Item name="version" label="版本" rules={[{ required: true }]}>
           <Select options={versionOptions} />
+        </Form.Item>
+        {willDownloadVersion && (
+          <Typography.Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
+            此版本不存在于本地缓存，将在{changeAction ?? '保存'}实例时自动下载
+          </Typography.Text>
+        )}
+        <Form.Item name="checkUpdateEnabled" valuePropName="checked">
+          <Checkbox>允许检查更新时提示该实例可更新</Checkbox>
         </Form.Item>
         <Form.Item label="WebUI监听地址" required>
           <Space.Compact style={{ width: '100%' }}>

--- a/src/hooks/useBatchUpgrade.ts
+++ b/src/hooks/useBatchUpgrade.ts
@@ -3,27 +3,37 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { api } from '../api';
 import { message } from '../antdStatic';
 import { useAppStore } from '../stores';
-import { handleApiError } from '../utils';
+import { getErrorMessage, handleApiError, parseProcessLockingError } from '../utils';
 import type { DeployProgress, GitHubRelease, InstanceStatus } from '../types';
+
+export interface LockCheckItem {
+  instance: InstanceStatus;
+  detail: string;
+  lockingProcesses: string[];
+}
 
 export interface BatchUpgradeState {
   open: boolean;
+  phase: 'confirm' | 'lockCheck' | 'upgrading' | 'done' | 'error';
   total: number;
   currentIndex: number;
   currentInstanceName: string;
   step: string | null;
   progress: number;
   error: string | null;
+  lockCheckItems: LockCheckItem[];
 }
 
 const INITIAL_STATE: BatchUpgradeState = {
   open: false,
+  phase: 'confirm',
   total: 0,
   currentIndex: 0,
   currentInstanceName: '',
   step: null,
   progress: 0,
   error: null,
+  lockCheckItems: [],
 };
 
 export function useBatchUpgrade(releases: GitHubRelease[]) {
@@ -31,6 +41,7 @@ export function useBatchUpgrade(releases: GitHubRelease[]) {
   const unlistenRef = useRef<UnlistenFn | null>(null);
   const instancesRef = useRef<InstanceStatus[]>([]);
   const latestVersionRef = useRef<string | null>(null);
+  const currentInstanceIdRef = useRef<string | null>(null);
 
   const cleanupListener = useCallback(() => {
     if (unlistenRef.current) {
@@ -42,6 +53,7 @@ export function useBatchUpgrade(releases: GitHubRelease[]) {
   const open = useCallback((instances: InstanceStatus[], latestVersion: string) => {
     instancesRef.current = instances;
     latestVersionRef.current = latestVersion;
+    currentInstanceIdRef.current = null;
     setState({
       ...INITIAL_STATE,
       open: true,
@@ -60,91 +72,166 @@ export function useBatchUpgrade(releases: GitHubRelease[]) {
     setState(INITIAL_STATE);
   }, [cleanupListener]);
 
+  const runUpgrade = useCallback(
+    async (instances: InstanceStatus[]) => {
+      const latestVersion = latestVersionRef.current;
+      if (!latestVersion || instances.length === 0) {
+        return;
+      }
+
+      setState((prev) => ({
+        ...prev,
+        phase: 'upgrading',
+        currentIndex: 0,
+        currentInstanceName: instances[0]?.name ?? '',
+        step: null,
+        progress: 0,
+        error: null,
+        lockCheckItems: [],
+      }));
+
+      try {
+        unlistenRef.current = await listen<DeployProgress>('deploy-progress', (event) => {
+          const { instance_id, step, progress } = event.payload;
+          const currentId = currentInstanceIdRef.current;
+          if (currentId && instance_id !== currentId) {
+            return;
+          }
+          setState((prev) => ({
+            ...prev,
+            step,
+            progress,
+          }));
+        });
+
+        const { versions } = useAppStore.getState();
+        if (!versions.some((v) => v.version === latestVersion)) {
+          const release = releases.find((r) => r.tag_name === latestVersion);
+          if (!release) {
+            throw new Error(`版本 ${latestVersion} 不存在`);
+          }
+
+          setState((prev) => ({
+            ...prev,
+            currentInstanceName: '下载版本',
+            step: null,
+            progress: 0,
+          }));
+          currentInstanceIdRef.current = null;
+          await api.installVersion(release);
+        }
+
+        for (let i = 0; i < instances.length; i++) {
+          const instance = instances[i];
+          currentInstanceIdRef.current = instance.id;
+          setState((prev) => ({
+            ...prev,
+            currentIndex: i,
+            currentInstanceName: instance.name,
+            step: null,
+            progress: 0,
+          }));
+
+          await api.updateInstance(
+            instance.id,
+            instance.name,
+            latestVersion,
+            instance.configured_host,
+            instance.configured_port,
+            instance.check_update_enabled
+          );
+        }
+
+        currentInstanceIdRef.current = null;
+        setState((prev) => ({
+          ...prev,
+          phase: 'done',
+          currentIndex: instances.length,
+          currentInstanceName: '',
+          step: 'done',
+          progress: 100,
+        }));
+        message.success('批量更新完成');
+      } catch (error) {
+        handleApiError(error);
+        setState((prev) => ({
+          ...prev,
+          phase: 'error',
+          error: getErrorMessage(error) || '更新过程中出现错误，请查看日志',
+        }));
+      } finally {
+        cleanupListener();
+      }
+    },
+    [releases, cleanupListener]
+  );
+
   const start = useCallback(async () => {
     const instances = instancesRef.current;
-    const latestVersion = latestVersionRef.current;
-    if (!latestVersion || instances.length === 0) {
+    if (instances.length === 0) {
       return;
     }
 
     setState((prev) => ({
       ...prev,
-      currentIndex: 0,
-      currentInstanceName: instances[0]?.name ?? '',
+      phase: 'lockCheck',
+      currentInstanceName: '检查文件锁',
       step: null,
       progress: 0,
       error: null,
+      lockCheckItems: [],
     }));
 
+    const lockCheckItems: LockCheckItem[] = [];
     try {
-      unlistenRef.current = await listen<DeployProgress>('deploy-progress', (event) => {
-        const { step, progress } = event.payload;
-        setState((prev) => ({
-          ...prev,
-          step,
-          progress,
-        }));
-      });
-
-      const { versions } = useAppStore.getState();
-      if (!versions.some((v) => v.version === latestVersion)) {
-        const release = releases.find((r) => r.tag_name === latestVersion);
-        if (!release) {
-          throw new Error(`版本 ${latestVersion} 不存在`);
+      for (const instance of instances) {
+        try {
+          await api.checkLock({ target: 'instance_upgrade', instanceId: instance.id });
+        } catch (error) {
+          const lockError = parseProcessLockingError(error);
+          if (!lockError) {
+            throw error;
+          }
+          if (!lockError.canContinue) {
+            throw new Error(`实例 ${instance.name} 被锁定：${lockError.detail}`);
+          }
+          lockCheckItems.push({
+            instance,
+            detail: lockError.detail,
+            lockingProcesses: lockError.lockingProcesses,
+          });
         }
-
-        setState((prev) => ({
-          ...prev,
-          currentInstanceName: '下载版本',
-          step: null,
-          progress: 0,
-        }));
-        await api.installVersion(release);
       }
 
-      for (let i = 0; i < instances.length; i++) {
-        const instance = instances[i];
+      if (lockCheckItems.length > 0) {
         setState((prev) => ({
           ...prev,
-          currentIndex: i,
-          currentInstanceName: instance.name,
-          step: null,
-          progress: 0,
+          phase: 'confirm',
+          lockCheckItems,
         }));
-
-        await api.updateInstance(
-          instance.id,
-          instance.name,
-          latestVersion,
-          instance.configured_host,
-          instance.configured_port,
-          instance.check_update_enabled
-        );
+        return;
       }
 
-      setState((prev) => ({
-        ...prev,
-        currentIndex: instances.length,
-        currentInstanceName: '',
-        step: 'done',
-        progress: 100,
-      }));
-      message.success('批量更新完成');
+      await runUpgrade(instances);
     } catch (error) {
       handleApiError(error);
       setState((prev) => ({
         ...prev,
-        error: '更新过程中出现错误，请查看日志',
+        phase: 'error',
+        error: getErrorMessage(error) || '检查文件锁失败',
       }));
-    } finally {
-      cleanupListener();
     }
-  }, [releases, cleanupListener]);
+  }, [runUpgrade]);
+
+  const continueAfterLockCheck = useCallback(() => {
+    void runUpgrade(instancesRef.current);
+  }, [runUpgrade]);
 
   return {
     state,
     open,
     start,
+    continueAfterLockCheck,
     close,
     resetAfterClose,
   };

--- a/src/hooks/useBatchUpgrade.ts
+++ b/src/hooks/useBatchUpgrade.ts
@@ -1,0 +1,151 @@
+import { useCallback, useRef, useState } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { api } from '../api';
+import { message } from '../antdStatic';
+import { useAppStore } from '../stores';
+import { handleApiError } from '../utils';
+import type { DeployProgress, GitHubRelease, InstanceStatus } from '../types';
+
+export interface BatchUpgradeState {
+  open: boolean;
+  total: number;
+  currentIndex: number;
+  currentInstanceName: string;
+  step: string | null;
+  progress: number;
+  error: string | null;
+}
+
+const INITIAL_STATE: BatchUpgradeState = {
+  open: false,
+  total: 0,
+  currentIndex: 0,
+  currentInstanceName: '',
+  step: null,
+  progress: 0,
+  error: null,
+};
+
+export function useBatchUpgrade(releases: GitHubRelease[]) {
+  const [state, setState] = useState<BatchUpgradeState>(INITIAL_STATE);
+  const unlistenRef = useRef<UnlistenFn | null>(null);
+  const instancesRef = useRef<InstanceStatus[]>([]);
+  const latestVersionRef = useRef<string | null>(null);
+
+  const cleanupListener = useCallback(() => {
+    if (unlistenRef.current) {
+      unlistenRef.current();
+      unlistenRef.current = null;
+    }
+  }, []);
+
+  const open = useCallback((instances: InstanceStatus[], latestVersion: string) => {
+    instancesRef.current = instances;
+    latestVersionRef.current = latestVersion;
+    setState({
+      ...INITIAL_STATE,
+      open: true,
+      total: instances.length,
+      currentInstanceName: instances[0]?.name ?? '',
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    cleanupListener();
+    setState((prev) => ({ ...prev, open: false }));
+  }, [cleanupListener]);
+
+  const resetAfterClose = useCallback(() => {
+    cleanupListener();
+    setState(INITIAL_STATE);
+  }, [cleanupListener]);
+
+  const start = useCallback(async () => {
+    const instances = instancesRef.current;
+    const latestVersion = latestVersionRef.current;
+    if (!latestVersion || instances.length === 0) {
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      currentIndex: 0,
+      currentInstanceName: instances[0]?.name ?? '',
+      step: null,
+      progress: 0,
+      error: null,
+    }));
+
+    try {
+      unlistenRef.current = await listen<DeployProgress>('deploy-progress', (event) => {
+        const { step, progress } = event.payload;
+        setState((prev) => ({
+          ...prev,
+          step,
+          progress,
+        }));
+      });
+
+      const { versions } = useAppStore.getState();
+      if (!versions.some((v) => v.version === latestVersion)) {
+        const release = releases.find((r) => r.tag_name === latestVersion);
+        if (!release) {
+          throw new Error(`版本 ${latestVersion} 不存在`);
+        }
+
+        setState((prev) => ({
+          ...prev,
+          currentInstanceName: '下载版本',
+          step: null,
+          progress: 0,
+        }));
+        await api.installVersion(release);
+      }
+
+      for (let i = 0; i < instances.length; i++) {
+        const instance = instances[i];
+        setState((prev) => ({
+          ...prev,
+          currentIndex: i,
+          currentInstanceName: instance.name,
+          step: null,
+          progress: 0,
+        }));
+
+        await api.updateInstance(
+          instance.id,
+          instance.name,
+          latestVersion,
+          instance.configured_host,
+          instance.configured_port,
+          instance.check_update_enabled
+        );
+      }
+
+      setState((prev) => ({
+        ...prev,
+        currentIndex: instances.length,
+        currentInstanceName: '',
+        step: 'done',
+        progress: 100,
+      }));
+      message.success('批量更新完成');
+    } catch (error) {
+      handleApiError(error);
+      setState((prev) => ({
+        ...prev,
+        error: '更新过程中出现错误，请查看日志',
+      }));
+    } finally {
+      cleanupListener();
+    }
+  }, [releases, cleanupListener]);
+
+  return {
+    state,
+    open,
+    start,
+    close,
+    resetAfterClose,
+  };
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -647,7 +647,7 @@ export default function Dashboard() {
               type="primary"
               icon={<PlusOutlined />}
               onClick={() => setCreateOpen(true)}
-              disabled={releasesLoading && versions.length === 0}
+              disabled={versionOptions.length === 0}
               loading={releasesLoading}
             >
               创建实例

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
   InputNumber,
   Select,
   Tag,
+  Alert,
   Typography,
 } from 'antd';
 import { PlusOutlined, UpOutlined } from '@ant-design/icons';
@@ -26,7 +27,7 @@ import { EditInstanceModal } from '../components/EditInstanceModal';
 import { LockCheckConfirmModal } from '../components/LockCheckConfirmModal';
 import { BatchUpgradeModal } from '../components/BatchUpgradeModal';
 import { PageHeader } from '../components/PageHeader';
-import { handleApiError } from '../utils';
+import { handleApiError, getErrorMessage } from '../utils';
 import { STATUS_MESSAGES, OPERATION_KEYS } from '../constants';
 import { buildDashboardColumns } from './dashboardColumns';
 import { useBatchUpgrade } from '../hooks/useBatchUpgrade';
@@ -95,6 +96,7 @@ export default function Dashboard() {
   // All available releases (used for creation / editing)
   const [releases, setReleases] = useState<GitHubRelease[]>([]);
   const [releasesLoading, setReleasesLoading] = useState(false);
+  const [releasesError, setReleasesError] = useState<string | null>(null);
   const batchUpgrade = useBatchUpgrade(releases);
 
   // Stable content-based key to avoid re-running the effect when the instances
@@ -151,31 +153,33 @@ export default function Dashboard() {
     };
   }, [config?.check_instance_update, instanceVersionKeys, instances]);
 
-  useEffect(() => {
-    let cancelled = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+  const fetchReleases = useCallback(async (cancelledRef?: { current: boolean }) => {
     setReleasesLoading(true);
-
-    void api
-      .fetchReleases()
-      .then((data) => {
-        if (!cancelled) {
-          setReleases(data);
-        }
-      })
-      .catch(() => {
-        // Silently ignore fetch errors
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setReleasesLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
+    setReleasesError(null);
+    try {
+      const data = await api.fetchReleases();
+      if (!cancelledRef?.current) {
+        setReleases(data);
+      }
+    } catch (error) {
+      if (!cancelledRef?.current) {
+        setReleasesError(getErrorMessage(error) || '获取版本列表失败');
+      }
+    } finally {
+      if (!cancelledRef?.current) {
+        setReleasesLoading(false);
+      }
+    }
   }, []);
+
+  useEffect(() => {
+    const cancelled = { current: false };
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchReleases(cancelled);
+    return () => {
+      cancelled.current = true;
+    };
+  }, [fetchReleases]);
 
   // ========================================
   // Instance Actions
@@ -509,24 +513,34 @@ export default function Dashboard() {
 
   const installedVersionSet = useMemo(() => new Set(versions.map((v) => v.version)), [versions]);
 
-  const versionOptions = useMemo(
-    () =>
-      releases.map((release) => ({
+  const versionOptions = useMemo(() => {
+    if (releases.length === 0 && versions.length > 0) {
+      return versions.map((v) => ({
         label: (
           <Space>
-            {release.name || release.tag_name}
-            {installedVersionSet.has(release.tag_name) ? (
-              <Tag color="green">已下载</Tag>
-            ) : (
-              <Tag>未下载</Tag>
-            )}
-            {release.prerelease && <Tag color="orange">预发行</Tag>}
+            {v.version}
+            <Tag color="green">已下载</Tag>
           </Space>
         ),
-        value: release.tag_name,
-      })),
-    [releases, installedVersionSet]
-  );
+        value: v.version,
+      }));
+    }
+
+    return releases.map((release) => ({
+      label: (
+        <Space>
+          {release.name || release.tag_name}
+          {installedVersionSet.has(release.tag_name) ? (
+            <Tag color="green">已下载</Tag>
+          ) : (
+            <Tag>未下载</Tag>
+          )}
+          {release.prerelease && <Tag color="orange">预发行</Tag>}
+        </Space>
+      ),
+      value: release.tag_name,
+    }));
+  }, [releases, versions, installedVersionSet]);
 
   const upgradableInstances = useMemo(
     () => (latestVersion ? instances.filter((inst) => instanceUpdateMap[inst.id]) : []),
@@ -633,7 +647,7 @@ export default function Dashboard() {
               type="primary"
               icon={<PlusOutlined />}
               onClick={() => setCreateOpen(true)}
-              disabled={releasesLoading || releases.length === 0}
+              disabled={releasesLoading && versions.length === 0}
               loading={releasesLoading}
             >
               创建实例
@@ -641,6 +655,21 @@ export default function Dashboard() {
           </Space>
         }
       />
+
+      {releasesError && (
+        <Alert
+          message="获取版本列表失败"
+          description={releasesError}
+          type="error"
+          showIcon
+          action={
+            <Button size="small" onClick={() => fetchReleases()}>
+              重试
+            </Button>
+          }
+          style={{ marginBottom: 16 }}
+        />
+      )}
 
       <Table
         dataSource={instances}
@@ -761,6 +790,7 @@ export default function Dashboard() {
         instances={upgradableInstances}
         latestVersion={latestVersion}
         onStart={batchUpgrade.start}
+        onContinueAfterLockCheck={batchUpgrade.continueAfterLockCheck}
         onClose={handleBatchUpgradeClose}
       />
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,18 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Table, Modal, Form, Input, InputNumber, Select, Alert, Typography } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
+import {
+  Button,
+  Space,
+  Table,
+  Modal,
+  Form,
+  Input,
+  InputNumber,
+  Select,
+  Tag,
+  Typography,
+} from 'antd';
+import { PlusOutlined, UpOutlined } from '@ant-design/icons';
 import { api } from '../api';
 import { message } from '../antdStatic';
 import type { InstanceStatus, GitHubRelease } from '../types';
@@ -13,10 +24,12 @@ import { DeployProgressModal } from '../components/DeployProgressModal';
 import { ConfirmModal } from '../components/ConfirmModal';
 import { EditInstanceModal } from '../components/EditInstanceModal';
 import { LockCheckConfirmModal } from '../components/LockCheckConfirmModal';
+import { BatchUpgradeModal } from '../components/BatchUpgradeModal';
 import { PageHeader } from '../components/PageHeader';
 import { handleApiError } from '../utils';
 import { STATUS_MESSAGES, OPERATION_KEYS } from '../constants';
 import { buildDashboardColumns } from './dashboardColumns';
+import { useBatchUpgrade } from '../hooks/useBatchUpgrade';
 
 type InstanceActionOptions<T> = {
   id: string;
@@ -33,6 +46,7 @@ type PendingUpgradeEdit = {
   version: string;
   host: string;
   port: number;
+  checkUpdateEnabled: boolean;
 };
 
 export default function Dashboard() {
@@ -61,6 +75,7 @@ export default function Dashboard() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [singleUpgradeInstance, setSingleUpgradeInstance] = useState<InstanceStatus | null>(null);
   const [editingInstance, setEditingInstance] = useState<InstanceStatus | null>(null);
   const [instanceToDelete, setInstanceToDelete] = useState<InstanceStatus | null>(null);
   const {
@@ -71,10 +86,16 @@ export default function Dashboard() {
 
   // Forms
   const [createForm] = Form.useForm();
+  const selectedCreateVersion = Form.useWatch('version', createForm);
 
   // Version update hints
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [instanceUpdateMap, setInstanceUpdateMap] = useState<Record<string, boolean>>({});
+
+  // All available releases (used for creation / editing)
+  const [releases, setReleases] = useState<GitHubRelease[]>([]);
+  const [releasesLoading, setReleasesLoading] = useState(false);
+  const batchUpgrade = useBatchUpgrade(releases);
 
   // Stable content-based key to avoid re-running the effect when the instances
   // array reference changes but the actual items are identical (e.g. after snapshot refresh).
@@ -108,6 +129,9 @@ export default function Dashboard() {
         const latest = stable.tag_name;
         const entries = await Promise.all(
           instances.map(async (inst) => {
+            if (!inst.check_update_enabled) {
+              return [inst.id, false] as const;
+            }
             const cmp = await api.compareVersions(latest, inst.version);
             return [inst.id, cmp > 0] as const;
           })
@@ -125,7 +149,33 @@ export default function Dashboard() {
     return () => {
       cancelled = true;
     };
-  }, [config?.check_instance_update, instanceVersionKeys]);
+  }, [config?.check_instance_update, instanceVersionKeys, instances]);
+
+  useEffect(() => {
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setReleasesLoading(true);
+
+    void api
+      .fetchReleases()
+      .then((data) => {
+        if (!cancelled) {
+          setReleases(data);
+        }
+      })
+      .catch(() => {
+        // Silently ignore fetch errors
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setReleasesLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // ========================================
   // Instance Actions
@@ -139,8 +189,13 @@ export default function Dashboard() {
         task: async () => {
           const { versions: latestVersions } = useAppStore.getState();
           if (!latestVersions.some((v) => v.version === values.version)) {
-            message.warning('所选版本不存在，请先刷新后重试');
-            return SKIP_OPERATION;
+            const release = releases.find((r) => r.tag_name === values.version);
+            if (!release) {
+              message.warning('所选版本不存在，请先刷新后重试');
+              return SKIP_OPERATION;
+            }
+            message.info(`正在下载版本 ${values.version}...`);
+            await api.installVersion(release);
           }
 
           await api.createInstance(values.name, values.version, values.port ?? 0);
@@ -150,9 +205,12 @@ export default function Dashboard() {
           setCreateOpen(false);
           createForm.resetFields();
         },
+        onError: (error) => {
+          handleApiError(error);
+        },
       });
     },
-    [createForm, runOperation]
+    [createForm, releases, runOperation]
   );
 
   const runInstanceEdit = useCallback(
@@ -177,8 +235,13 @@ export default function Dashboard() {
           }
 
           if (!latestVersions.some((v) => v.version === payload.version)) {
-            message.warning('所选版本不存在，请先刷新后重试');
-            return SKIP_OPERATION;
+            const release = releases.find((r) => r.tag_name === payload.version);
+            if (!release) {
+              message.warning('所选版本不存在，请先刷新后重试');
+              return SKIP_OPERATION;
+            }
+            message.info(`正在下载版本 ${payload.version}...`);
+            await api.installVersion(release);
           }
 
           const versionChanged = payload.version !== latestInstance.version;
@@ -203,7 +266,8 @@ export default function Dashboard() {
             payload.name,
             payload.version,
             payload.host,
-            payload.port
+            payload.port,
+            payload.checkUpdateEnabled
           );
         },
         onSuccess: () => {
@@ -232,11 +296,24 @@ export default function Dashboard() {
         },
       });
     },
-    [startDeploy, closeDeploy, runOperation, closeUpgradeLockModal, handleUpgradeLockCheckError]
+    [
+      startDeploy,
+      closeDeploy,
+      runOperation,
+      closeUpgradeLockModal,
+      handleUpgradeLockCheckError,
+      releases,
+    ]
   );
 
   const handleEdit = useCallback(
-    async (values: { name: string; version: string; host: string; port?: number }) => {
+    async (values: {
+      name: string;
+      version: string;
+      host: string;
+      port?: number;
+      checkUpdateEnabled: boolean;
+    }) => {
       if (!editingInstance) return;
 
       await runInstanceEdit({
@@ -245,9 +322,11 @@ export default function Dashboard() {
         version: values.version,
         host: values.host,
         port: values.port ?? 0,
+        checkUpdateEnabled: values.checkUpdateEnabled,
       });
+      await rebuildSnapshotFromDisk();
     },
-    [editingInstance, runInstanceEdit]
+    [editingInstance, runInstanceEdit, rebuildSnapshotFromDisk]
   );
 
   const handleContinueUpgradeAfterLockCheckFailure = useCallback(
@@ -428,6 +507,60 @@ export default function Dashboard() {
     [navigate]
   );
 
+  const installedVersionSet = useMemo(() => new Set(versions.map((v) => v.version)), [versions]);
+
+  const versionOptions = useMemo(
+    () =>
+      releases.map((release) => ({
+        label: (
+          <Space>
+            {release.name || release.tag_name}
+            {installedVersionSet.has(release.tag_name) ? (
+              <Tag color="green">已下载</Tag>
+            ) : (
+              <Tag>未下载</Tag>
+            )}
+            {release.prerelease && <Tag color="orange">预发行</Tag>}
+          </Space>
+        ),
+        value: release.tag_name,
+      })),
+    [releases, installedVersionSet]
+  );
+
+  const upgradableInstances = useMemo(
+    () => (latestVersion ? instances.filter((inst) => instanceUpdateMap[inst.id]) : []),
+    [instances, instanceUpdateMap, latestVersion]
+  );
+
+  const openUpgradeModal = useCallback((instance: InstanceStatus) => {
+    setSingleUpgradeInstance(instance);
+  }, []);
+
+  const handleConfirmSingleUpgrade = useCallback(async () => {
+    if (!singleUpgradeInstance || !latestVersion) return;
+    const instance = singleUpgradeInstance;
+    setSingleUpgradeInstance(null);
+    await runInstanceEdit({
+      instanceId: instance.id,
+      name: instance.name,
+      version: latestVersion,
+      host: instance.configured_host,
+      port: instance.configured_port,
+      checkUpdateEnabled: instance.check_update_enabled,
+    });
+  }, [singleUpgradeInstance, latestVersion, runInstanceEdit]);
+
+  const handleBatchUpgrade = useCallback(() => {
+    if (!latestVersion || upgradableInstances.length === 0) return;
+    batchUpgrade.open(upgradableInstances, latestVersion);
+  }, [batchUpgrade, latestVersion, upgradableInstances]);
+
+  const handleBatchUpgradeClose = useCallback(() => {
+    batchUpgrade.resetAfterClose();
+    void rebuildSnapshotFromDisk();
+  }, [batchUpgrade, rebuildSnapshotFromDisk]);
+
   const columns = useMemo(
     () =>
       buildDashboardColumns({
@@ -447,6 +580,7 @@ export default function Dashboard() {
         onEdit: openEditModal,
         onDelete: openDeleteModal,
         onViewLogs: handleViewLogs,
+        onUpgrade: openUpgradeModal,
       }),
     [
       deployProgress,
@@ -465,13 +599,10 @@ export default function Dashboard() {
       openEditModal,
       openDeleteModal,
       handleViewLogs,
+      openUpgradeModal,
     ]
   );
 
-  const versionOptions = useMemo(
-    () => versions.map((v) => ({ label: v.version, value: v.version })),
-    [versions]
-  );
   const upgradeLockModalLoading =
     upgradeLockModal?.mode === 'checkFailed'
       ? operations[OPERATION_KEYS.instance(upgradeLockModal.payload.instanceId)] || false
@@ -488,25 +619,28 @@ export default function Dashboard() {
         onRefresh={() => rebuildSnapshotFromDisk()}
         refreshLoading={loading}
         actions={
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => setCreateOpen(true)}
-            disabled={versions.length === 0}
-          >
-            创建实例
-          </Button>
+          <Space>
+            {upgradableInstances.length > 0 && (
+              <Button
+                icon={<UpOutlined />}
+                onClick={handleBatchUpgrade}
+                disabled={batchUpgrade.state.open}
+              >
+                批量更新 ({upgradableInstances.length})
+              </Button>
+            )}
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              onClick={() => setCreateOpen(true)}
+              disabled={releasesLoading || releases.length === 0}
+              loading={releasesLoading}
+            >
+              创建实例
+            </Button>
+          </Space>
         }
       />
-
-      {initialized && versions.length === 0 && (
-        <Alert
-          title="请先在「版本」页面下载 AstrBot 版本后再创建实例"
-          type="warning"
-          showIcon
-          style={{ marginBottom: 16 }}
-        />
-      )}
 
       <Table
         dataSource={instances}
@@ -537,6 +671,11 @@ export default function Dashboard() {
           <Form.Item name="version" label="版本" rules={[{ required: true }]}>
             <Select options={versionOptions} placeholder="选择版本" />
           </Form.Item>
+          {selectedCreateVersion && !installedVersionSet.has(selectedCreateVersion) && (
+            <Typography.Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
+              此版本不存在于本地缓存，将在创建实例时自动下载
+            </Typography.Text>
+          )}
           <Form.Item name="port" label="端口">
             <InputNumber
               min={0}
@@ -551,7 +690,8 @@ export default function Dashboard() {
       <EditInstanceModal
         open={editOpen}
         instance={editingInstance}
-        versions={versions}
+        releases={releases}
+        installedVersions={installedVersionSet}
         onSubmit={handleEdit}
         onCancel={() => {
           setEditOpen(false);
@@ -586,6 +726,42 @@ export default function Dashboard() {
         loading={upgradeLockModalLoading}
         onContinue={handleContinueUpgradeAfterLockCheckFailure}
         onClose={closeUpgradeLockModal}
+      />
+
+      {/* Single Upgrade Modal */}
+      <ConfirmModal
+        open={singleUpgradeInstance !== null}
+        title="确认更新实例"
+        content={
+          <>
+            <p>确定要将此实例升级到最新版本吗？</p>
+            {singleUpgradeInstance && (
+              <Typography.Text type="secondary">
+                实例名称: {singleUpgradeInstance.name}
+                <br />
+                当前版本: {singleUpgradeInstance.version}
+                <br />
+                目标版本: {latestVersion}
+              </Typography.Text>
+            )}
+          </>
+        }
+        loading={
+          singleUpgradeInstance
+            ? operations[OPERATION_KEYS.instance(singleUpgradeInstance.id)] || false
+            : false
+        }
+        lockOnLoading
+        onConfirm={handleConfirmSingleUpgrade}
+        onCancel={() => setSingleUpgradeInstance(null)}
+      />
+
+      <BatchUpgradeModal
+        state={batchUpgrade.state}
+        instances={upgradableInstances}
+        latestVersion={latestVersion}
+        onStart={batchUpgrade.start}
+        onClose={handleBatchUpgradeClose}
       />
 
       {/* Deploy Progress Modal */}

--- a/src/pages/dashboardColumns.tsx
+++ b/src/pages/dashboardColumns.tsx
@@ -23,6 +23,7 @@ interface DashboardColumnsOptions {
   onEdit: (instance: InstanceStatus) => void;
   onDelete: (instance: InstanceStatus) => void;
   onViewLogs: (instance: InstanceStatus) => void;
+  onUpgrade: (instance: InstanceStatus) => void;
 }
 
 export function buildDashboardColumns({
@@ -42,6 +43,7 @@ export function buildDashboardColumns({
   onEdit,
   onDelete,
   onViewLogs,
+  onUpgrade,
 }: DashboardColumnsOptions): TableColumnsType<InstanceStatus> {
   return [
     {
@@ -75,18 +77,31 @@ export function buildDashboardColumns({
       dataIndex: 'version',
       key: 'version',
       width: 120,
-      render: (version: string, record: InstanceStatus) => (
-        <Space size={4}>
-          <span>{version}</span>
-          {instanceUpdateMap[record.id] && latestVersion && (
-            <Tooltip title={`最新版本: ${latestVersion}`}>
-              <Tag color="blue" style={{ marginInlineEnd: 0 }}>
-                可更新
-              </Tag>
-            </Tooltip>
-          )}
-        </Space>
-      ),
+      render: (version: string, record: InstanceStatus) => {
+        const upgradable = instanceUpdateMap[record.id] && latestVersion;
+        const upgrading = operations[OPERATION_KEYS.instance(record.id)] || false;
+
+        return (
+          <Space size={4}>
+            <span>{version}</span>
+            {upgradable && (
+              <Tooltip title={upgrading ? '更新中...' : `点击升级到最新版本: ${latestVersion}`}>
+                <Tag
+                  color="blue"
+                  style={{
+                    marginInlineEnd: 0,
+                    cursor: upgrading ? 'not-allowed' : 'pointer',
+                    opacity: upgrading ? 0.6 : 1,
+                  }}
+                  onClick={upgrading ? undefined : () => onUpgrade(record)}
+                >
+                  可更新
+                </Tag>
+              </Tooltip>
+            )}
+          </Space>
+        );
+      },
     },
     {
       title: '操作',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,7 @@ export interface InstanceStatus {
   pid_tracker_not_available: boolean;
   configured_host: string;
   configured_port: number;
+  check_update_enabled: boolean;
 }
 
 // ========================================


### PR DESCRIPTION
Introduce a batch upgrade modal for managing instance upgrades, along with an upgrade tag for instances. Implement an auto-download feature for versions and a toggle to enable or disable updates on a per-instance basis. This enhances the user experience by streamlining the upgrade process.

## Summary by Sourcery

Streamline instance upgrades by adding configurable update notifications, automatic version downloads, and guided single- or batch-upgrade workflows.

New Features:
- Add single-instance and batch upgrade workflows with confirmation, file-lock checks, progress tracking, and error handling.
- Display upgrade availability tags and actions for instances, including a batch update action for all eligible instances.
- Allow selecting remote releases and automatically download versions when creating or updating instances.

Bug Fixes:
- Respect each instance's update-check preference when determining and displaying available upgrades.

Enhancements:
- Add a per-instance setting to enable or disable update notifications, with backward-compatible defaults for existing configurations.
- Show release metadata and local download status in instance creation and editing flows.